### PR TITLE
Fix sync_pairs

### DIFF
--- a/src/cryptocom/exchange/private.py
+++ b/src/cryptocom/exchange/private.py
@@ -26,6 +26,7 @@ class Account:
 
     async def sync_pairs(self):
         await self.exchange.sync_pairs()
+        self.pairs = self.exchange.pairs
 
     async def get_balance(self) -> Dict[Coin, Balance]:
         """Return balance."""


### PR DESCRIPTION
Currently, function only syncs the Exchange part of the Account. The Account pairs are not updated.